### PR TITLE
feat: auto-seed 500 records on container startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,4 +98,6 @@ ENV API_V1_PREFIX="/api/v1"
 # 127.0.0.1 would make it unreachable from the host machine.
 # For local Docker: use uvicorn directly
 # Run migrations, then start the server
-CMD alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-10000}
+CMD alembic upgrade head && \
+    python scripts/seed_database.py --count 500 || true && \
+    uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-10000}


### PR DESCRIPTION
## Summary

This PR includes the change regarding the auto-seed of 500 records if there is empty data.

## Type of Change

- [x] Feature (new functionality)
- [ ] Fix (bug fix)
- [ ] Docs (documentation update)
- [ ] Chore (dependency update, refactor, test improvement)

## What Was Changed

The change here is in the `CMD` instruction in the Dockerfile:

**Before:**
```dockerfile
CMD alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-10000}
```

**After:**
```dockerfile
CMD alembic upgrade head && \
    python scripts/seed_database.py --count 500 || true && \
    uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-10000}
```